### PR TITLE
Fixes I needed to get this running

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is painful to manually unload/load kext every time you plugin your phone for 
 
 ### HOW
 
-Edit the included plist file and add your phone's vendor and product id to it. You can add multiple device ids. Also change the Path to where your `HoRNDIS-Reloader` binary is located.
+Edit the included plist file and add your phone's vendor and product id to it in the form <vendor-id>:<product-id>. You can add multiple device ids. Also change the Path to where your `HoRNDIS-Reloader` binary is located.
 
 ```xml
 <array>

--- a/iokitnative.go
+++ b/iokitnative.go
@@ -116,7 +116,7 @@ func AddDeviceMatch(vendorID, productID int) {
 			unsafe.Pointer(numberRef))
 	}
 
-	C.CFRelease(numberRef)
+	C.CFRelease(C.CFTypeRef(numberRef))
 
 	numberRef = C.CFNumberCreate(C.kCFAllocatorDefault, C.kCFNumberSInt32Type,
 		unsafe.Pointer(&productID))
@@ -127,7 +127,7 @@ func AddDeviceMatch(vendorID, productID int) {
 			unsafe.Pointer(numberRef))
 	}
 
-	C.CFRelease(numberRef)
+	C.CFRelease(C.CFTypeRef(numberRef))
 
 	numberRef = nil
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 import "strconv"
 
-const Kext = "/System/Library/Extensions/HoRNDIS.kext"
+const Kext = "/Library/Extensions/HoRNDIS.kext"
 
 var c = make(chan int, 10)
 


### PR DESCRIPTION
First of all, thanks for writing this tool! I had a few issues getting it running, so I figured I'd at least document the changes I needed.

* Fix build error with iokitnative.go. Was seeing this issue:
```
./iokitnative.go:119: cannot use numberRef (type C.CFNumberRef) as type C.CFTypeRef in argument to func literal
./iokitnative.go:130: cannot use numberRef (type C.CFNumberRef) as type C.CFTypeRef in argument to func literal
```

* Change location of kext to /Library/Extensions/HoRNDIS.kext (OSX Sierra fails to load kext otherwise due to being unsigned). Might not want this change if you want to support older versions of OSX. Fix was found here : https://github.com/jwise/HoRNDIS/issues/42). Was seeing this issue:
```
└─(Extensions)-> sudo kextutil HoRNDIS.kext/
Diagnostics for /System/Library/Extensions/HoRNDIS.kext:
Code Signing Failure: not code signed
Untrusted kexts are not allowed
ERROR: invalid signature for com.joshuawise.kexts.HoRNDIS, will not load
```

* Update README clarifying the ordering of the phone vendor and product id in the plist file.